### PR TITLE
feat(.github): `ConfigParser` adds `Type() string` for informing the user which parser is being used.

### DIFF
--- a/config_file_type.go
+++ b/config_file_type.go
@@ -50,6 +50,11 @@ type ConfigFileType struct {
 	ConfigType
 }
 
+// Type returns which parser is in use.
+func (f *ConfigFileType) Type() string {
+	return "Not Implemented"
+}
+
 // Stat checks if the file exists and computes the platform specific Path and
 // directly writes to the provided diagnostics.
 func (f *ConfigFileType) Stat(diags *diag.Diagnostics, component diag.Component, cfg *Config, dirPath string) bool {

--- a/config_typeable.go
+++ b/config_typeable.go
@@ -1,23 +1,22 @@
 package configurator
 
 import (
-	"fmt"
-
 	"github.com/matthewhartstonge/configurator/diag"
 )
 
 type ConfigTypeable interface {
-	fmt.Stringer
-
 	ConfigParser
 	ConfigImplementer
 }
 
 type ConfigFileParser interface {
+	// Stat returns false if a file can't be found by the parser.
 	Stat(diags *diag.Diagnostics, component diag.Component, cfg *Config, dirPath string) bool
 }
 
 type ConfigParser interface {
+	// Type informs the user as to which parser is being used.
+	Type() string
 	// Parse returns the direct file path of the file that was parsed and any
 	// associated errors returned from parsing the file.
 	Parse(cfg *Config) (string, error)

--- a/configurator.go
+++ b/configurator.go
@@ -192,7 +192,7 @@ func processConfig(diags diag.Diagnostics, component diag.Component, cfg *Config
 	path, err := configurer.Parse(cfg)
 	if err != nil {
 		// Low-level parsing issue
-		diags.FromComponent(component, configurer.String()).
+		diags.FromComponent(component, configurer.Type()).
 			Error(fmt.Sprintf("Error parsing %s configuration", component),
 				err.Error())
 		return cfg, diags

--- a/env/envconfig/envconfig.go
+++ b/env/envconfig/envconfig.go
@@ -22,7 +22,7 @@ type EnvConfig struct {
 	configurator.ConfigType
 }
 
-func (e EnvConfig) String() string {
+func (e EnvConfig) Type() string {
 	return "EnvConfig configurator"
 }
 

--- a/file/hcl/hcl.go
+++ b/file/hcl/hcl.go
@@ -27,7 +27,7 @@ type HCL struct {
 	configurator.ConfigFileType
 }
 
-func (h HCL) String() string {
+func (h HCL) Type() string {
 	return "HCL Configurator"
 }
 

--- a/file/json/json.go
+++ b/file/json/json.go
@@ -22,6 +22,6 @@ type JSON struct {
 	configurator.ConfigFileType
 }
 
-func (j JSON) String() string {
+func (j JSON) Type() string {
 	return "JSON configurator"
 }

--- a/file/toml/toml.go
+++ b/file/toml/toml.go
@@ -22,6 +22,6 @@ type TOML struct {
 	configurator.ConfigFileType
 }
 
-func (t TOML) String() string {
+func (t TOML) Type() string {
 	return "TOML configurator"
 }

--- a/file/yaml/yaml.go
+++ b/file/yaml/yaml.go
@@ -22,6 +22,6 @@ type YAML struct {
 	configurator.ConfigFileType
 }
 
-func (y YAML) String() string {
+func (y YAML) Type() string {
 	return "YAML configurator"
 }


### PR DESCRIPTION
- `ConfigParser` adds `Type() string` for informing the user which parser is being used.
- `ConfigTypeable` interface removes `fmt.Stringer` requirement.